### PR TITLE
TPM Counters to prevent rollback

### DIFF
--- a/docs/safeboot.md
+++ b/docs/safeboot.md
@@ -82,12 +82,16 @@ this automatically.
 
 ## pcrs-sign
 Usage:
-safeboot pcrs-sign [path-to-unified-kernel]
+safeboot pcrs-sign [prevent-rollback] [path-to-unified-kernel]
 
 Generate a signature for the PCRs that can be used to unseal the LUKS key
 according to the policy created by `safeboot luks-seal`.  The PCRs used
 are specified in the `/etc/safeboot/safeboot.conf` or `local.conf` files, and
 must match the values that were configured during `luks-seal`.
+
+If the prevent-rollback argument is `prevent-rollback`, the TPM version counter
+will be incremented, which will invalidate all previous PCR signatures and prevent
+the older unified kernel images from being able to unseal the PCR data.
 
 The signature is persisted in a UEFI NVRAM variable, defined in `safeboot.conf`.
 
@@ -104,8 +108,11 @@ be required on the next normal boot in place of the recovery code.
 
 If this is the first time the disk has been sealed, `/etc/crypttab`
 will be updated to include a call to the unsealing script to retrieve
-the keys from the TPM.  After running this it is necessary to
-to rebuild the initrd, and then re-run `sudo linux-sign && sudo pcrs-sign`
+the keys from the TPM, and a counter will be created to prevent rollbacks.
+
+After sealing the secret, the initrd will be rebuild, the kernel signed,
+and the new predicted PCRs signed.  Any previous sealed data will be
+invalidated since the version counter will be incremented.
 
 Right now only a single crypt disk is supported.
 

--- a/initramfs/hooks/tpm-unseal
+++ b/initramfs/hooks/tpm-unseal
@@ -37,10 +37,3 @@ copy_file safeboot-keys "$(dirname "$CERT")/$(basename "$CERT" .pem).pub" "$DIR/
 if [ -r "$DIR/local.conf" ]; then
 	copy_file safeboot-local "$DIR/local.conf"
 fi
-
-# If there are sealed LUKS secrets, move them too
-if [ -r "$DIR/sealed.public" ]; then
-	copy_file safeboot-sealed "$DIR/sealed.policy"
-	copy_file safeboot-sealed "$DIR/sealed.public"
-	copy_file safeboot-sealed "$DIR/sealed.secret"
-fi

--- a/safeboot.conf
+++ b/safeboot.conf
@@ -37,8 +37,7 @@ TPM_NV_VERSION=0x1500010
 # The TPM sealed secret is stored at this handle
 TPM_SEALED_HANDLE=0x81110000
 
-# PCR Signature is stored in this TPM NVRAM address
-TPM_NV_SIGNATURE=0x1500011
+# PCR Signature is stored in this UEFI NVRAM variable
 PCR_SIGNATURE=SafebootPCR-8620893e-c793-457e-8a02-41fc83eef3ce
 
 # Is a PIN required?

--- a/safeboot.conf
+++ b/safeboot.conf
@@ -29,7 +29,16 @@ SIP=0
 PCRS=0,2,4,5,7
 BOOTMODE_PCR=14
 
-# PCR Signature is stored in this UEFI NVRAM variable
+# The TPM NVRAM used to store the upgrade counter.
+# Each time a new kernel is signed the counter at this nvram index
+# can be incremented to invalidate any older signatures
+TPM_NV_VERSION=0x1500010
+
+# The TPM sealed secret is stored at this handle
+TPM_SEALED_HANDLE=0x81110000
+
+# PCR Signature is stored in this TPM NVRAM address
+TPM_NV_SIGNATURE=0x1500011
 PCR_SIGNATURE=SafebootPCR-8620893e-c793-457e-8a02-41fc83eef3ce
 
 # Is a PIN required?

--- a/sbin/safeboot
+++ b/sbin/safeboot
@@ -109,13 +109,17 @@ tpm2_flushall() {
 }
 
 efivar() {
+	if [ -z "$1" ]; then
+		die "efivar: variable name required"
+	fi
 	var="/sys/firmware/efi/efivars/$1"
 	chattr -i "$var"
 
 	printf "\x07\x00\x00\x00" > "$TMP/efivar.bin"
 	cat - >> "$TMP/efivar.bin"
-	xxd -g1 "$TMP/efivar.bin"
+	#xxd -g1 "$TMP/efivar.bin"
 
+	warn "$var: writing new value"
 	cat "$TMP/efivar.bin" > "$var"
 }
 
@@ -510,7 +514,7 @@ uefi-set-keys()
 tpm2_create_policy()
 {
 	PCR_FILE="$1"
-	VERSION="$2-0123456789abcdef"
+	VERSION="${2-0123456789abcdef}"
 
 	tpm2_flushall
 
@@ -528,22 +532,6 @@ tpm2_create_policy()
 		>> /tmp/tpm.log \
 	|| die "Unable to start TPM auth session"
 
-	if [ "$SEAL_PIN" = "1" ]; then
-		# Add an Auth Value policy, which will require the PIN for unsealing
-		tpm2 policyauthvalue \
-			--session "$TMP/session.ctx" \
-			>> /tmp/tpm.log \
-		|| die "Unable to create auth value policy"
-	fi
-
-	echo -n "$VERSION" | hex2bin | \
-	tpm2 policynv \
-		--session "$TMP/session.ctx" \
-		"$TPM_NV_VERSION" eq \
-		--input "-" \
-		>> /tmp/tpm.log \
-	|| die "Unable to create version policy"
-
 	tpm2 policypcr \
 		--session "$TMP/session.ctx" \
 		--pcr-list "sha256:$PCRS,$BOOTMODE_PCR" \
@@ -551,6 +539,25 @@ tpm2_create_policy()
 		--policy "$TMP/pcr.policy" \
 		>> /tmp/tpm.log \
 	|| die "Unable to create PCR policy"
+
+	if [ "$SEAL_PIN" = "1" ]; then
+		# Add an Auth Value policy, which will require the PIN for unsealing
+		tpm2 policyauthvalue \
+			--session "$TMP/session.ctx" \
+			--policy "$TMP/pcr.policy" \
+			>> /tmp/tpm.log \
+		|| die "Unable to create auth value policy"
+	fi
+
+	warn "Using TPM counter $VERSION"
+	echo -n "$VERSION" | hex2bin \
+	tpm2 policynv \
+		--session "$TMP/session.ctx" \
+		"$TPM_NV_VERSION" eq \
+		--input "-" \
+		--policy "$TMP/pcr.policy" \
+		>> /tmp/tpm.log \
+	|| die "Unable to create version policy"
 
 	tpm2 policyauthorize \
 		--session "$TMP/session.ctx" \
@@ -615,6 +622,9 @@ pcrs-sign() {
 	# This works on the Thinkpad X1, which extends PCR4
 	# with EFI_EV_SEPARATOR and then the PE hash of the EFI_BOOT_APPLICATION
 	linux_hash="$(sbsign.safeboot --hash-only "$linux")"
+	if [ "$?" != "0" ]; then
+		die "$linux: PE hash failed"
+	fi
 	ev_sep="$(printf "\x00\x00\x00\x00" | tpm2_trial_extend 0)"
 	pcr4_computed="$(echo -n "${ev_sep}${linux_hash}" | hex2bin | sha256)"
 
@@ -763,7 +773,7 @@ luks-seal() {
 	fi
 
 	# Ensure that there is a TPM counter at the desired address
-	tpm2 nvundef \
+	tpm2 nvundefine \
 		"$TPM_NV_VERSION" \
 		>> /tmp/tpm.log \
 	|| warn "Unable to remove old TPM counter $TPM_NV_VERSION"
@@ -806,7 +816,7 @@ luks-seal() {
 		--policy "$TMP/signed.policy" \
 		--sealing-input "$TMP/key.bin" \
 		${SEAL_PIN1:+ --key-auth "$SEAL_PIN1" } \
-		--public "$TMP/sealed.public" \
+		--public "$TMP/sealed.pub" \
 		--private "$TMP/sealed.priv" \
 		>> /tmp/tpm.log \
 	|| die "Unable to create TPM key context"
@@ -876,7 +886,7 @@ luks-seal() {
 	linux-sign "$LINUX_TARGET" \
 	|| die "Unable to sign kernel"
 
-	pcrs-sign "$LINUX_TARGET" "0123456789abcdef" \
+	pcrs-sign "allow-rollback" "$LINUX_TARGET" \
 	|| die "Unable to sign PCRs"
 }
 

--- a/sbin/safeboot
+++ b/sbin/safeboot
@@ -768,14 +768,15 @@ luks-seal() {
 	# Ask for a PIN that will be used to decrypt, if configured
 	if [ "$SEAL_PIN" = "1" ]; then
 		while true; do
-			read -r -s -p "Unsealing PIN: " SEAL_PIN1
-			echo
-			read -r -s -p "PIN again: " SEAL_PIN2
+			read -r -s -p "New unsealing PIN: " SEAL_PIN1
 			echo
 			if [ "$SEAL_PIN1" = "" ]; then
 				echo >&2 'PIN must not be empty, unset $SEAL_PIN in /etc/safeboot/local.conf instead'
 				continue
 			fi
+
+			read -r -s -p "Unsealing PIN again: " SEAL_PIN2
+			echo
 			if [ "$SEAL_PIN1" = "$SEAL_PIN2" ]; then
 				break
 			fi

--- a/sbin/safeboot
+++ b/sbin/safeboot
@@ -56,6 +56,14 @@ die() { echo "$die_msg""$*" >&2 ; exit 1 ; }
 warn() { echo "$@" >&2 ; }
 debug() { [ "$VERBOSE" == 1 ] && echo "$@" >&2 ; }
 
+tpm2() {
+	if [ "$VERBOSE" == 1 ]; then
+		/usr/bin/time -f '%E %C' /usr/sbin/tpm2 "$@"
+	else
+		/usr/sbin/tpm2 "$@"
+	fi
+}
+
 cleanup() {
 	if [ "$TMP_MOUNT" == "y" ]; then
 		warn "$TMP: Unmounting"
@@ -550,7 +558,7 @@ tpm2_create_policy()
 	fi
 
 	warn "Using TPM counter $VERSION"
-	echo -n "$VERSION" | hex2bin \
+	echo -n "$VERSION" | hex2bin | \
 	tpm2 policynv \
 		--session "$TMP/session.ctx" \
 		"$TPM_NV_VERSION" eq \
@@ -621,10 +629,7 @@ pcrs-sign() {
 	# for the Linux kernel (which will be loaded as the boot application).
 	# This works on the Thinkpad X1, which extends PCR4
 	# with EFI_EV_SEPARATOR and then the PE hash of the EFI_BOOT_APPLICATION
-	linux_hash="$(sbsign.safeboot --hash-only "$linux")"
-	if [ "$?" != "0" ]; then
-		die "$linux: PE hash failed"
-	fi
+	linux_hash="$(sbsign.safeboot --hash-only "$linux" || die "unable to hash")"
 	ev_sep="$(printf "\x00\x00\x00\x00" | tpm2_trial_extend 0)"
 	pcr4_computed="$(echo -n "${ev_sep}${linux_hash}" | hex2bin | sha256)"
 
@@ -848,6 +853,8 @@ luks-seal() {
 			's: luks: keyscript=/usr/sbin/safeboot-tpm-unseal,luks:' \
 			$PREFIX/etc/crypttab \
 		|| die "$PREFIX/etc/crypttab: unable to add keyscript"
+
+		need_update_initramfs=1
 	fi
 
 	# ask for the disk encryption key
@@ -880,12 +887,17 @@ luks-seal() {
 
 	warn "$dev: sealed with PCR $PCRS,$BOOTMODE_PCR"
 
-	update-initramfs -u \
-	|| die "Unable to update initramfs"
+	if [ -n "$need_update_initramfs" ]; then
+		warn "-------- Need to update initramfs --------"
+		update-initramfs -u \
+		|| die "Unable to update initramfs"
 
-	linux-sign "$LINUX_TARGET" \
-	|| die "Unable to sign kernel"
+		warn "-------- Need to sign new kernel --------"
+		linux-sign "$LINUX_TARGET" \
+		|| die "Unable to sign kernel"
+	fi
 
+	warn "-------- Need to sign PCR and counter values --------"
 	pcrs-sign "allow-rollback" "$LINUX_TARGET" \
 	|| die "Unable to sign PCRs"
 }

--- a/sbin/safeboot
+++ b/sbin/safeboot
@@ -522,7 +522,13 @@ uefi-set-keys()
 tpm2_create_policy()
 {
 	PCR_FILE="$1"
-	VERSION="${2-0123456789abcdef}"
+	if [ -n "$2" ]; then
+		VERSION="$2"
+		warn "Using TPM counter $VERSION"
+	else
+		VERSION="0123456789abcdef"
+		warn "Using placeholder TPM counter version"
+	fi
 
 	tpm2_flushall
 
@@ -557,7 +563,6 @@ tpm2_create_policy()
 		|| die "Unable to create auth value policy"
 	fi
 
-	warn "Using TPM counter $VERSION"
 	echo -n "$VERSION" | hex2bin | \
 	tpm2 policynv \
 		--session "$TMP/session.ctx" \

--- a/sbin/safeboot
+++ b/sbin/safeboot
@@ -506,8 +506,12 @@ uefi-set-keys()
 
 # Create the TPM policy for sealing/unsealing the disk encryption key
 # If an optional argument is provided, use that for the PCR data
+# If an second optional argument is provided, use that for the version counter file
 tpm2_create_policy()
 {
+	PCR_FILE="$1"
+	VERSION="$2-0123456789abcdef"
+
 	tpm2_flushall
 
 	tpm2 loadexternal \
@@ -532,10 +536,18 @@ tpm2_create_policy()
 		|| die "Unable to create auth value policy"
 	fi
 
+	echo -n "$VERSION" | hex2bin | \
+	tpm2 policynv \
+		--session "$TMP/session.ctx" \
+		"$TPM_NV_VERSION" eq \
+		--input "-" \
+		>> /tmp/tpm.log \
+	|| die "Unable to create version policy"
+
 	tpm2 policypcr \
 		--session "$TMP/session.ctx" \
 		--pcr-list "sha256:$PCRS,$BOOTMODE_PCR" \
-		${1:+ --pcr "$1" } \
+		${PCR_FILE:+ --pcr "$PCR_FILE" } \
 		--policy "$TMP/pcr.policy" \
 		>> /tmp/tpm.log \
 	|| die "Unable to create PCR policy"
@@ -555,12 +567,16 @@ tpm2_create_policy()
 pcrs_sign_usage='
 ## pcrs-sign
 Usage:
-safeboot pcrs-sign [path-to-unified-kernel]
+safeboot pcrs-sign [prevent-rollback] [path-to-unified-kernel]
 
 Generate a signature for the PCRs that can be used to unseal the LUKS key
 according to the policy created by `safeboot luks-seal`.  The PCRs used
 are specified in the `/etc/safeboot/safeboot.conf` or `local.conf` files, and
 must match the values that were configured during `luks-seal`.
+
+If the prevent-rollback argument is `prevent-rollback`, the TPM version counter
+will be incremented, which will invalidate all previous PCR signatures and prevent
+the older unified kernel images from being able to unseal the PCR data.
 
 The signature is persisted in a UEFI NVRAM variable, defined in `safeboot.conf`.
 '
@@ -569,16 +585,28 @@ commands+="|pcrs-sign"
 
 pcrs-sign() {
 	show_help "$1" "$pcrs_sign_usage"
-	if [ -n "$1" ]; then
-		linux="$1"
-		shift
-	else
-		linux="$EFIDIR/$LINUX_TARGET/linux.efi"
+
+	prevent_rollback="${1}"
+	target="${2-linux}"
+	linux="$EFIDIR/$target/linux.efi"
+
+	if [ "$prevent_rollback" = "prevent-rollback" ]; then
+		warn "$linux: Incrementing TPM version to prevent rollback"
+		tpm2 nvincrement \
+			"$TPM_NV_VERSION" \
+			>> /tmp/tpm.log \
+		|| die "Unable to increment TPM version $TPM_NV_VERSION"
 	fi
+
+	tpm2 nvread \
+		"$TPM_NV_VERSION" \
+		> "$TMP/nv_version.bin" \
+	|| die "Unable to read TPM version $TPM_NV_VERSION"
+	VERSION="$(xxd -g8 "$TMP/nv_version.bin" | awk '{print $2}')"
+	warn "$linux: TPM version $VERSION"
 
 	# If pre-computed PCRs are known, they can be used here instead
 	# TODO: allow PCRs to be passed in
-	# TODO: use the computed PCR4 for the linux kernel
 	tpm2 pcrread -o "$TMP/pcrs.bin" "sha256:$PCRS" \
 	|| die "Unable to read TPM PCRs"
 
@@ -616,12 +644,14 @@ pcrs-sign() {
 	# will only unseal during a normal boot, not a recovery boot.
 	# the unseal script will also extend PCR14 after unsealing
 	# to prevent the TPM from unsealing the secret a second time
+	#
+	# TODO: Fix the ordering if the boot mode PCR is not the last on the list
 	pcr14=$(echo -n "${LINUX_TARGET}" | tpm2_trial_extend $PCR_DEFAULT)
 	warn "mode=${LINUX_TARGET} PCR$BOOTMODE_PCR=$pcr14"
 	echo -n "$pcr14" | hex2bin \
 		>> "$TMP/pcrs.bin"
 
-	tpm2_create_policy "$TMP/pcrs.bin"
+	tpm2_create_policy "$TMP/pcrs.bin" "$VERSION"
 
 	openssl dgst \
 		-sha256 \
@@ -653,8 +683,11 @@ be required on the next normal boot in place of the recovery code.
 
 If this is the first time the disk has been sealed, `/etc/crypttab`
 will be updated to include a call to the unsealing script to retrieve
-the keys from the TPM.  After running this it is necessary to
-to rebuild the initrd, and then re-run `sudo linux-sign && sudo pcrs-sign`
+the keys from the TPM, and a counter will be created to prevent rollbacks.
+
+After sealing the secret, the initrd will be rebuild, the kernel signed,
+and the new predicted PCRs signed.  Any previous sealed data will be
+invalidated since the version counter will be incremented.
 
 Right now only a single crypt disk is supported.
 
@@ -729,6 +762,24 @@ luks-seal() {
 		done
 	fi
 
+	# Ensure that there is a TPM counter at the desired address
+	tpm2 nvundef \
+		"$TPM_NV_VERSION" \
+		>> /tmp/tpm.log \
+	|| warn "Unable to remove old TPM counter $TPM_NV_VERSION"
+
+	tpm2 nvdefine \
+		"$TPM_NV_VERSION" \
+		--attributes 'authread|authwrite|nt=counter' \
+		--size 8 \
+		>> /tmp/tpm.log \
+	|| die "Unable to create TPM counter $TPM_NV_VERSION"
+
+	tpm2 nvincrement \
+		"$TPM_NV_VERSION" \
+		>> /tmp/tpm.log \
+	|| die "Unable to initialize TPM counter $TPM_NV_VERSION"
+
 	tpm2_create_policy
 
 	dd \
@@ -741,7 +792,9 @@ luks-seal() {
 		2>/dev/null \
 	|| die "Unable to generate random key"
 
-	warn "Sealing secret with TPM, storing sealed secret in $PREFIX$DIR"
+	warn "Sealing secret with TPM, storing sealed secret in $TPM_NV_VERSION"
+
+	tpm2_flushall
 
 	tpm2 createprimary \
 		--key-context "$TMP/primary.ctx" \
@@ -753,10 +806,29 @@ luks-seal() {
 		--policy "$TMP/signed.policy" \
 		--sealing-input "$TMP/key.bin" \
 		${SEAL_PIN1:+ --key-auth "$SEAL_PIN1" } \
-		--public "$PREFIX$DIR/sealed.public" \
-		--private "$PREFIX$DIR/sealed.secret" \
+		--public "$TMP/sealed.public" \
+		--private "$TMP/sealed.priv" \
 		>> /tmp/tpm.log \
 	|| die "Unable to create TPM key context"
+
+	tpm2 load \
+		--parent-context "$TMP/primary.ctx" \
+		--public "$TMP/sealed.pub" \
+		--private "$TMP/sealed.priv" \
+		--name "$TMP/sealed.name" \
+		--key-context "$TMP/sealed.ctx" \
+	|| die "Unable to load sealed object into TPM"
+
+	tpm2 evictcontrol \
+		--hierarchy owner \
+		--object-context "$TPM_SEALED_HANDLE" \
+	|| warn "Unable to evict existing sealed handle $TPM_SEALED_HANDLE, ignoring"
+
+	tpm2 evictcontrol \
+		--hierarchy owner \
+		--object-context "$TMP/sealed.ctx" \
+		"$TPM_SEALED_HANDLE" \
+	|| die "Unable to persist sealed data into the TPM"
 
 	# make sure the crypttab has the unlock script referenced
 	if ! grep keyscript "$PREFIX/etc/crypttab" > /dev/null ; then
@@ -800,6 +872,12 @@ luks-seal() {
 
 	update-initramfs -u \
 	|| die "Unable to update initramfs"
+
+	linux-sign "$LINUX_TARGET" \
+	|| die "Unable to sign kernel"
+
+	pcrs-sign "$LINUX_TARGET" "0123456789abcdef" \
+	|| die "Unable to sign PCRs"
 }
 
 ########################################

--- a/sbin/safeboot-tpm-unseal
+++ b/sbin/safeboot-tpm-unseal
@@ -84,10 +84,18 @@ tpm2 startauthsession \
 	>> /tmp/tpm.log \
 || die "Unable to start policy session"
 
+tpm2 policypcr \
+	--session "/tmp/session.ctx" \
+	--pcr-list "sha256:$PCRS,$BOOTMODE_PCR" \
+	--policy "/tmp/pcr.policy" \
+	>> /tmp/tpm.log \
+|| die "Unable to create PCR policy"
+
 if [ "$SEAL_PIN" = "1" ]; then
 	# Add an auth value, which will require the PIN for unsealing
 	tpm2 policyauthvalue \
 		--session "/tmp/session.ctx" \
+		--policy "/tmp/pcr.policy" \
 		>> /tmp/tpm.log \
 	|| die "Unable to create auth value policy"
 fi
@@ -97,15 +105,9 @@ tpm2 nvread "$TPM_NV_VERSION" \
 	--session "/tmp/session.ctx" \
 	"$TPM_NV_VERSION" eq \
 	--input "-" \
-	>> /tmp/tpm.log \
-|| die "Unable to load TPM version counter"
-
-tpm2 policypcr \
-	--session "/tmp/session.ctx" \
-	--pcr-list "sha256:$PCRS,$BOOTMODE_PCR" \
 	--policy "/tmp/pcr.policy" \
 	>> /tmp/tpm.log \
-|| die "Unable to create PCR policy"
+|| die "Unable to load TPM version counter"
 
 log "TPM: Loading RSA public key"
 tpm2 loadexternal \

--- a/sbin/safeboot-tpm-unseal
+++ b/sbin/safeboot-tpm-unseal
@@ -77,21 +77,6 @@ fi
 tpm2 flushcontext --transient-object
 tpm2 flushcontext --loaded-session
 
-log "TPM: Loading sealed secret"
-tpm2 createprimary \
-	--key-context "/tmp/primary.ctx" \
-	>> /tmp/tpm.log \
-|| die "Unable to create primary context for sealed secret"
-
-tpm2 load \
-	--parent-context "/tmp/primary.ctx" \
-	--public "/etc/safeboot/sealed.public" \
-	--private "/etc/safeboot/sealed.secret" \
-	--name "/tmp/sealed.name" \
-	--key-context "/tmp/sealed.ctx" \
-	>> /tmp/tpm.log \
-|| die "Unable to load sealed secret into TPM"
-
 log "TPM: Starting auth session"
 tpm2 startauthsession \
 	--policy-session \
@@ -107,6 +92,14 @@ if [ "$SEAL_PIN" = "1" ]; then
 	|| die "Unable to create auth value policy"
 fi
 
+tpm2 nvread "$TPM_NV_VERSION" \
+| tpm2 policynv \
+	--session "/tmp/session.ctx" \
+	"$TPM_NV_VERSION" eq \
+	--input "-" \
+	>> /tmp/tpm.log \
+|| die "Unable to load TPM version counter"
+
 tpm2 policypcr \
 	--session "/tmp/session.ctx" \
 	--pcr-list "sha256:$PCRS,$BOOTMODE_PCR" \
@@ -117,7 +110,7 @@ tpm2 policypcr \
 log "TPM: Loading RSA public key"
 tpm2 loadexternal \
 	--key-algorithm rsa \
-	--hierarchy o \
+	--hierarchy owner \
 	--public "/etc/safeboot/cert.pub" \
 	--key-context "/tmp/key.ctx" \
 	--name "/tmp/key.name" \
@@ -166,7 +159,7 @@ tpm2_unseal()
 	PIN="$1"
 	tpm2 unseal \
 		--auth "session:/tmp/session.ctx$PIN" \
-		--object-context "/tmp/sealed.ctx" \
+		--object-context "$TPM_SEALED_HANDLE" \
 		> /tmp/secret.bin \
 	|| return $?
 

--- a/sbin/safeboot-tpm-unseal
+++ b/sbin/safeboot-tpm-unseal
@@ -176,17 +176,24 @@ if [ "$SEAL_PIN" != "1" ]; then
 	tpm2_unseal ""
 else
 	for tries in 1 2 3; do
-		# Use the askpass program to try to get a pin
-		# retrieve a tpmtotp attestation so that the user knows
-		# that the firmware is unmodified and that it is safe to
-		# enter their credentials.
-		totp="$(/usr/sbin/tpm2-totp --time calculate || echo TPM TOTP FAILED)"
-		msg="$totp $MODE (Try $tries)
+		while true; do
+			# Use the askpass program to try to get a pin
+			# retrieve a tpmtotp attestation so that the user knows
+			# that the firmware is unmodified and that it is safe to
+			# enter their credentials.
+			totp="$(/usr/sbin/tpm2-totp --time calculate || echo TPM TOTP FAILED)"
+			msg="$totp $MODE (Try $tries)
 
-Enter unseal PIN for $CRYPTTAB_SOURCE ($CRYPTTAB_NAME): "
+	Enter unseal PIN for $CRYPTTAB_SOURCE ($CRYPTTAB_NAME): "
 
-		PIN="$(/lib/cryptsetup/askpass "$msg")"
+			PIN="$(/lib/cryptsetup/askpass "$msg")"
 
+			if [ "$PIN" != "" ]; then
+				break
+			fi
+		done
+
+		# try to unseal with the provided PIN
 		tpm2_unseal "+$PIN"
 	done
 fi

--- a/sbin/safeboot-tpm-unseal
+++ b/sbin/safeboot-tpm-unseal
@@ -54,7 +54,6 @@ log "TPM mode=$MODE pcrs=$PCRS $BOOTMODE_PCR"
 
 if [ "$MODE" = "recovery" ] \
 || [ -r "/tmp/unseal-failed" ] \
-|| [ ! -r "/etc/safeboot/sealed.public" ] \
 ; then
 	log "Falling back to user pass phrase"
 


### PR DESCRIPTION
This adds support for including a TPM counter variable in the signed signature, which will invalidate old signatures on sealed PCRs (#22).  The UEFI secure boot will still load the older kernel and initrd, but the TPM will refuse to unseal the disk encryption key since the version counter will have changed.

It also moves the sealed secret from the initrd into a persistent object, closing #60 

The totp value is recomputed if no password or PIN is given, closing #61 

The `luks-seal` operation now forces an initrd regeneration, kernel signing and pcr signing when a new key is sealed.