### PR TITLE
Fix typo in attestation page

### DIFF
--- a/attestation/index.html
+++ b/attestation/index.html
@@ -693,7 +693,7 @@ encrypted with the wrong EK.</p>
 <li>Validates that the quote is signed by the AK with the correct nonce (if the nonce is not checked, then this could be a replay attack by the Client)</li>
 <li>Server optionally consults its list of previously enrolled devices to verify that this EK is in an owner controlled machine</li>
 <li>Server optionally validates that the PCRs match the expected values</li>
-<li>Server optoinally validates that the TPM event log produces the set of
+<li>Server optionally validates that the TPM event log produces the set of
 PCR values in the quote</li>
 </ul>
 <p>If the command fails, then something is likely wrong on the Client side
@@ -701,7 +701,7 @@ and requires remediation.  The Server should not proceed to sealing a
 secret for the Client.</p>
 <p>Suprisingly, the Attestation Key is not signed by the Endorsement Key,
 so the Server has to check the EK certificate to ensure that it came from
-a real TPM. Additional, the Server must check the AK attributes to ensure
+a real TPM. Additionally, the Server must check the AK attributes to ensure
 that it has <code>fixedtpm</code> and <code>sensitivedataorigin</code> set, which indicates that
 the AK was generated inside the TPM. Even with these checks, the Server is
 still trusting that the TPM hardware implements <code>tpm2_activatecredential</code>
@@ -735,7 +735,7 @@ initial quote signing:</p>
 
 <p>With this command, the Client and TPM will:</p>
 <ul>
-<li>Initiates an encrypted session with the TPM and sends the blob to it.</li>
+<li>Initiate an encrypted session with the TPM and sends the blob to it.</li>
 <li>The TPM checks that the hash of the AK matches one that it generated and that it hasn't rebooted since then. If these checks pass, the TPM uses its private EK to decrypt the blob.</li>
 <li>Client receives the secret message over the encrypted channel to the TPM</li>
 </ul>


### PR DESCRIPTION
I suspect that:
* "optoinally" was meant to be "optionally"
* "Additional" was meant to be "Additionally"
* "Initiates" was meant to be "Initiate"