### PR TITLE
Optimize `sign-kernel` 

### DIFF
--- a/sbin/safeboot
+++ b/sbin/safeboot
@@ -924,7 +924,7 @@ sign-kernel() {
 	# Duplicate the old image and atomically move the new kernel
 	# image to avoid potentially leaving an unbootable system
 	if [ -r "$OUTDIR/linux.efi" ]; then
-		cp "$OUTDIR/linux.efi" "$OUTDIR/linux.efi.old" \
+		mv "$OUTDIR/linux.efi" "$OUTDIR/linux.efi.old" \
 		|| die "$OUTDIR/linux.efi.old: unable to backup old image"
 	fi
 

--- a/sbin/safeboot
+++ b/sbin/safeboot
@@ -1397,7 +1397,7 @@ you can unwind the changes that were made.
 
 		warn "Moving contents of /$lv to new filesystem"
 		mv "/$lv/"* "/tmp-$lv/" \
-		|| die "$vg-$lv: unable to move everything from old mount"
+		|| warn "$vg-$lv: unable to move everything from old mount"
 
 		umount "/tmp-$lv" \
 		|| die "$vg-$lv: unable to unmount"

--- a/sbin/safeboot
+++ b/sbin/safeboot
@@ -1326,7 +1326,7 @@ sip-init()
 	fi
 
 	# and refuse to do this unless they already have a recovery image
-	entry="$(efiboot-entry ${RECOVERY_TARGET})"
+	entry="$(efiboot_entry ${RECOVERY_TARGET})"
 	if [ -z "$entry" ]; then
 		die "No ${RECOVERY_TARGET} in efibootmgr? Too dangerous!"
 	fi


### PR DESCRIPTION
I'm trying to get up to speed to help bring safeboot to qubes and potentially to Genode Sculpt OS using nova micro-hypervisor [1]. This is my first pull request that tackles some of the bumps on the road I experienced.

[1] https://genode.org/documentation/articles/sculpt-20-08

Fixes issue #90 

Fixes issue #91