### PR TITLE
 Determine the correct partition number of the EFI system partition

### DIFF
--- a/sbin/safeboot
+++ b/sbin/safeboot
@@ -1004,13 +1004,14 @@ install-kernel() {
 	if ! efibootmgr | grep "^Boot.* $TARGET\$" ; then
 		# determine the device the EFI system partition is on
 		DEV="$(df "$OUTDIR" | tail -1 | cut -d' ' -f1)"
+		part=$(cat /sys/class/block/$(basename $DEV)/partition)
 
-		warn "$OUTDIR: Creating boot menu item on $DEV"
+		warn "$OUTDIR: Creating boot menu item on $DEV, partition $part"
 		efibootmgr \
 			--quiet \
 			--create \
 			--disk "$DEV" \
-			--part 1 \
+			--part $part \
 			--label "$TARGET" \
 			--loader "\\EFI\\$TARGET\\linux.efi" \
 		|| die "efibootmgr: failed to create $TARGET entry"


### PR DESCRIPTION
Currently the EFI system partition is assumed to be the first partition of the device. This needn't be the case.

This PR determines and uses the correct partition number of the EFI partition.