### PR TITLE
Complex policy expressions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,6 +307,7 @@ shellcheck:
 		sbin/tpm2-recv \
 		sbin/tpm2-policy \
 		initramfs/*/* \
+		tests/test-enroll.sh \
 	; do \
 		shellcheck $$file functions.sh ; \
 	done

--- a/docs/attest-enroll.md
+++ b/docs/attest-enroll.md
@@ -93,14 +93,14 @@ Decryption is implemented by [`sbin/tpm2-recv`](/sbin/tpm2-recv).
 
 Two methods are possible for encryption to a target TPM's `EKpub`:
 
- - the "EK" method (our name for it)
+ - the "WK" method (our name for it)
  - the "TK" method (our name for it)
 
 Both methods support setting a policy on the ciphertext such that any
 application using the target's TPM to decrypt it must first execute and
 satisfy that policy.
 
-The "EK" method uses `TPM2_MakeCredential()` via tpm2-tools' `tpm2
+The "WK" method uses `TPM2_MakeCredential()` via tpm2-tools' `tpm2
 makecredential` command, using the `none` TCTI (i.e., implemented in
 software).  The target's `EKpub` is used as the `handle` input parameter
 to `TPM2_MakeCredential()`.  A well-known key (`WK`), and the desired policy

--- a/functions.sh
+++ b/functions.sh
@@ -10,7 +10,7 @@ die() { echo "${PROG:+${PROG}: }$die_msg""$*" >&2 ; exit 1 ; }
 warn() { echo "$@" >&2 ; }
 error() { echo "$@" >&2 ; return 1 ; }
 info() { ((${VERBOSE:-0})) && echo "$@" >&2 ; return 0 ; }
-debug() { ((${VERBOSE:-0})) && echo "$@" >&2 ; return 0 ; }
+debug() { ((${VERBOSE:-0}>1)) && echo "$@" >&2 ; return 0 ; }
 
 
 ########################################
@@ -64,6 +64,7 @@ PCR_DEFAULT=0000000000000000000000000000000000000000000000000000000000000000
 
 TPM2="$(command -v tpm2 || true)"
 [[ -z $TPM2 ]] && warn "tpm2 program not found! things will probably break"
+[[ $TPM2 = tpm2 ]] && TPM2="command tpm2"
 
 # if the TPM2 resource manager is running, talk to it.
 # otherwise use a direct connection to the TPM
@@ -75,12 +76,12 @@ if ! pidof tpm2-abrmd > /dev/null ; then
 	fi
 fi
 
-
 tpm2() {
-	if ((${VERBOSE:-0})); then
-		/usr/bin/time -f '%E %C' "$TPM2" "$@"
+	if ((${VERBOSE:-0} > 2)); then
+		# shellcheck disable=SC2086
+		/usr/bin/time -f '%E %C' ${TPM2#command } "$@"
 	else
-		"$TPM2" "$@"
+		$TPM2 "$@"
 	fi
 }
 
@@ -495,45 +496,219 @@ aead_decrypt() {
 	fi
 }
 
-# Execute a policy given as arguments.
+indent() {
+	local depth=$((${depth:-0} + 1))
+
+	while ((depth > 0)); do printf '    '; ((depth--)); done
+}
+
+# subexp_length POLICY...
 #
-# The first argument may be a command code; if given, then {tpm2}
-# {policycommandcode} will be added to the given policy.  The rest must be
-# {tpm2_policy*} or {tpm2} {policy*} commands w/o any {--session}|{-c} or
-# {--policy}|{-L} arguments, and multiple commands may be given separate by
+# Returns the number of arguments making up a policy expression.  The caller
+# will presumably shift those into an array and exec that sub-policy.
+#
+# See {exec_policy} for details on {POLICY}.
+subexp_length() {
+	local -n nv="$1"
+	local i depth=0 startswithparen=false
+	shift
+
+	nv=0
+	for i in "$@"; do
+		((++nv))
+		if [[ $i = '(' ]]; then
+			((nv == 1)) && startswithparen=true
+			((++depth))
+		elif [[ $i = ')' ]]; then
+			((depth--)) || true
+			if ((depth == 0)) && $startswithparen; then
+				return 0;
+			fi
+		fi
+		((depth < 0)) && die "Missing open parenthesis in policy expression: $*"
+		((depth == 0)) && [[ $i = ';' ]] && return 0
+	done
+	((depth == 0)) || die "Missing close parenthesis in policy expression: $*"
+	return 0;
+}
+
+# exec_policy SESSIONCTX POLICYDAT [ALTERNATIVES] POLICY...
+#
+# Starts a policy session {SESSIONCTX} and executes the given {POLICY} in that
+# session, leaving the final policyDigest for the {POLICY} in {POLICYDAT}.
+#
+# {SESSIONCTX} is the name of a saved session context file.
+#
+# {POLICYDAT} is the name of a file into which to write the POLICY's digest.
+#
+# {ALTERNATIVES} is zero, one, or more integers 0 through 9 that are indices of
+# policy alternations in the {POLICY} that are to be executed.
+#
+# {POLICY} starts with an optional command-code and is followed by
+# {tpm2 policy*} command-lines as arguments, w/o any {--session}|{-c} or
+# {--policy|-L} arguments.  Multiple policy commands may be given, separated by
 # {';'}.
 #
-# E.g.,
+#	[TPM2_CC_*] tpm2 policy* ... ';' tpm2 policy* ... ';' ...
 #
-#	exec_policy TPM2_CC_ActivateCredential "$@"
-#	exec_policy tpm2 policypcr ... ';' tpm2 policysigned ...
-function exec_policy {
+# {tpm2 policyor} command-lines are special: the alternatives must be given as
+# separate arguments, either as a {POLICY} in parenthesis, or as policy
+# digests:
+#
+#	exec_policy sess pol tpm2 policyor '(' POLICY0 ')' '(' POLICY1 ')' ...
+#	exec_policy sess pol tpm2 policyor $digest0 $digest1 ...
+#	exec_policy sess pol tpm2 policyor '(' POLICY0 ')' $digest1...
+#
+# Do not specify a command-code if the {POLICY} includes any {tpm2 policyor}
+# commands.
+#
+# The output of this function is the digest of the {POLICYDAT} as it stands at
+# the end of {POLICY} execution.
+#
+# Simple policy example (no alternation):
+#
+#	exec_policy sp p TPM2_CC_ActivateCredential ';'		\
+#	    tpm2 policysecret --object-context endorsement
+#
+# Complex example (alternation):
+#
+#	# Compute digest of a policy that allows signing and decryption to
+#	# applications with access to the endorsement hierarchy:
+#	exec_policy sp p						\
+#	    tpm2 policyor						\
+#		'(' tpm2 policycommandcode TPM2_CC_Sign ')'		\
+#		'(' tpm2 policycommandcode TPM2_CC_RSA_Decrypt ')' ';'	\
+#		tpm2 policysecret --object-context endorsement
+#
+#	# Execute the same policy to sign:
+#	exec_policy 1 sp p						\
+#	    tpm2 policyor						\
+#		'(' tpm2 policycommandcode TPM2_CC_Sign ')'		\
+#		'(' tpm2 policycommandcode TPM2_CC_RSA_Decrypt ')' ';'	\
+#		tpm2 policysecret --object-context endorsement
+#
+#	# Execute the same policy to decrypt:
+#	exec_policy 1 sp p						\
+#	    tpm2 policyor						\
+#		'(' tpm2 policycommandcode TPM2_CC_Sign ')'		\
+#		'(' tpm2 policycommandcode TPM2_CC_RSA_Decrypt ')' ';'	\
+#		tpm2 policysecret --object-context endorsement
+exec_policy() {
+	local -a alternatives rm_policies
+	local depth=0 session policy
+	local trial=true
+
+	session=$1
+	policy=$2
+	shift 2
+
+	# Use a dynamic variable to keep track of alternatives.
+	rm_policies=()
+	alternatives=()
+	while (($# > 0)) && [[ $1 = @([0-9]) ]]; do
+		alternatives+=("$1")
+		shift
+	done
+
+	debug "$(indent)Running (in trial session): exec_policy_helper $*"
+	tpm2_flushsome
+	tpm2 startauthsession --session "$session"
+	exec_policy_helper "$@"
+
+	debug "$(indent)Running (in policy session): exec_policy_helper $*"
+	tpm2_flushsome
+	tpm2 startauthsession --session "$session"	\
+		--policy-session
+	trial=false
+	exec_policy_helper "$@"
+
+	rm -f "${rm_policies[@]}"
+}
+
+# make_policyDigest SESSIONCTX POLICYDAT [ALTERNATIVES] POLICY...
+#
+# Compute the policyDigest of a given {POLICY} by executing it in a trial
+# session, {SESSIONCTX}.  The policyDigest will be placed in {POLICYDAT}
+# (binary) and will be output on stdout (hex-encoded).
+#
+# See {exec_policy} for details on {POLICY}.
+make_policyDigest() {
+	local -a alternatives rm_policies
+	local depth=0 session policy
+	local trial=true
+
+	session=$1
+	policy=$2
+	shift 2
+
+	(($# > 0)) && [[ $1 = [0-9]* ]] &&	\
+	warn "Ignoring alternation alternatives to take when computing policyDigest"
+	while (($# > 0)) && [[ $1 = [0-9]* ]]; do
+		shift
+	done
+
+	rm -f "$policy"
+	rm_policies=()
+	alternatives=()
+	debug "$(indent)Running (in trial session): exec_policy_helper $*"
+	tpm2_flushsome
+	tpm2 startauthsession --session "$session"
+	exec_policy_helper "$@"
+	rm -f "${rm_policies[@]}"
+}
+
+# exec_policy_helper POLICY...
+exec_policy_helper() {
 	local command_code=''
 	local add_commandcode=true
 	local has_policy=false
+	local subexp_length
 	local -a cmd
 
-	if (($# > 0)) && [[ -z $1 || $1 = TPM2_CC_* ]]; then
+	(($# == 0)) && return 0
+
+	if [[ -z $1 || $1 = TPM2_CC_* ]]; then
 		command_code=$1
 		shift
 	fi
 	while (($# > 0)); do
-		has_policy=true
 		cmd=()
-		while (($# > 0)) && [[ $1 != ';' ]]; do
-			cmd+=("$1")
-			if ((${#cmd[@]} == 1)) && [[ ${cmd[0]} = tpm2_* ]]; then
-				cmd+=(	--session "${d}/session.ctx"
-					--policy "${d}/policy")
-			elif ((${#cmd[@]} == 2)) && [[ ${cmd[0]} = tpm2 ]]; then
-				cmd+=(	--session "${d}/session.ctx"
-					--policy "${d}/policy")
+		subexp_length=0
+		has_policy=true
+		subexp_length subexp_length "$@"
+
+		[[ "${*:$subexp_length:1}" = ';' ]] && ((subexp_length--))
+		if ((subexp_length > 0)) && [[ $1 = tpm2_* ]]; then
+			if [[ $1 = tpm2_policyor ]]; then
+				cmd=(exec_policyOR_helper)
+			else
+				cmd=("$1" --session "$session"
+					  --policy "$policy")
 			fi
+			((subexp_length--)) || true
 			shift
-		done
-		(($# > 0)) && shift
+		elif ((subexp_length > 1)) && [[ $1 = tpm2 ]]; then
+			if [[ $2 = policyor ]]; then
+				cmd=(exec_policyOR_helper)
+			else
+				cmd=("$1" "$2" --session "$session"
+					       --policy "$policy")
+			fi
+			((subexp_length -= 2)) || true
+			shift 2
+		fi
+
+		# Build ONE tpm2 policy* command-line (or exec_policyOR_helper)
+		cmd+=("${@:1:$subexp_length}")
+		shift "$subexp_length"
+		if [[ ${cmd[0]} = exec_policyOR_helper ]]; then
+			add_commandcode=false
+		fi
+		(($# > 0)) && [[ $1 = ';' ]] && shift
+
 		# Run the policy command in the temp dir.  It -or the last command- must
 		# leave a file there named 'policy'.
+		info "$(indent)Running: (AND) ${cmd[*]}"
 		"${cmd[@]}" 1>&2					\
 		|| die "unable to execute policy command: ${cmd[*]}"
 		[[ ${cmd[0]} = tpm2 ]] && ((${#cmd[@]} == 1))		\
@@ -544,33 +719,129 @@ function exec_policy {
 		&& add_commandcode=false
 	done
 	if $has_policy && $add_commandcode && [[ -n $command_code ]]; then
+		info "$(indent)Running: (AND) tpm2 policycommandcode --session $session --policy $policy $command_code"
 		tpm2 policycommandcode			\
-			--session "${d}/session.ctx"	\
-			--policy "${d}/policy"		\
+			--session "$session"	\
+			--policy "$policy"	\
 			"$command_code" 1>&2		\
 		|| die "unable to execute policy command: tpm2 policycommandcode $command_code"
 	fi
-	xxd -p -c 100 "${d}/policy"
+	xxd -p -c 100 "$policy"
 }
 
-# Compute the policyDigest of a given policy by executing it in a trial
-# session.
-function make_policyDigest {
-	tpm2 flushcontext --transient-object
-	tpm2 flushcontext --loaded-session
-	tpm2 startauthsession --session "${d}/session.ctx"
-	exec_policy "$@"
+exec_policyOR_helper() {
+	local npolicies=0
+	local subexp_length alt doit=false
+	local altsession='' altpolicy=''
+	local -a policyDigests
+	local -a policies
+	local -a cmd
+
+	# The alternative to take, if any
+	alt=${alternatives[$depth]:-"-1"}
+	policyDigests=()
+	policies=()
+	cmd=()
+
+	$trial || ((alt >= 0))	\
+	|| die "Missing alternatives at expression depth $depth"
+
+	while (($# > 0)); do
+		if [[ $1 = ';' ]]; then
+			break
+		fi
+		subexp_length=0
+		altsession="${session}-${depth}-${npolicies}"
+		altpolicy="${policy}-${depth}-${npolicies}"
+		policies+=("$altpolicy")
+		((++depth))
+		if [[ $1 = '(' ]]; then
+			if ! $trial && ((alt == npolicies)); then
+				# Execute this sub-policy in the main, policy
+				# session
+				altsession=$session
+				debug "$(indent)Using policy session $altsession"
+				doit=true
+			elif ! $trial && [[ -f $altpolicy ]]; then
+				debug "$(indent)Using previously computed policyDigest for sub-expression"
+				doit=false
+			else
+				# Execute this sub-policy in a trial session
+				debug "$(indent)Starting trial session $altsession"
+				debug "$(indent)-- trial=$trial altpolicy=$altpolicy"
+				tpm2 startauthsession --session "$altsession"
+				doit=true
+			fi
+			# Count the number of arguments for this
+			# sub-expression.  (Includes the two parens.)
+			subexp_length subexp_length "$@"
+			shift # open paren
+			((subexp_length -= 2)) || true # open and close parens
+
+			# Build command-line
+			cmd=(exec_policy_helper "${@:1:$subexp_length}")
+			shift "$subexp_length"
+			shift # close paren
+
+			if $doit; then
+				# Run it (changing the $session and $policy seen by the
+				# command-line)
+				debug "$(indent)Running: (OR) ${cmd[*]}"
+				session="$altsession"	\
+				policy="$altpolicy"	\
+				"${cmd[@]}"
+			fi
+
+			# Cleanup
+			if $trial || ((alt != npolicies)); then
+				# Reduce our burden on the TPM by flushing this
+				# trial session
+				[[ -f $altsession ]] && tpm2 flushcontext "$altsession"
+				rm -f "$altsession"
+			fi
+		elif [[ ${#1} == 64 && $1 = +([0-9a-fA-F]) ]]; then
+			# Alternative given as SHA-256 digest
+			echo "$1" | xxd -p -r > "${policy}-${depth}-$npolicies"
+			shift
+		elif [[ -f $1 ]] && (($(stat -c %s "$1") == 32)); then
+			# Alternative given as policy SHA-256 digest (binary) file
+			cp "$1" "${policy}-${depth}-$npolicies"
+			shift
+		else
+			die "Invalid policyor alternative"
+		fi
+		policyDigests+=("$(xxd -p -c 100 "$altpolicy")")
+		((++npolicies))
+		((depth--))
+	done
+	IFS=",$IFS"
+	set -- "${policies[*]}"
+	IFS="${IFS#,}"
+	info "$(indent)ORing: ${policyDigests[*]}"
+	info "$(indent)Running: tpm2 policyor --session $session --policy $policy sha256:$1"
+	tpm2 policyor --session "$session"	\
+		      --policy  "$policy"	\
+		      sha256:"$1"
+
+	# We leave these around so that we can first compute the
+	# policies in trial sessions then use a single policy session to
+	# evaluate the taken alternatives:
+	rm_policies+=("${policies[@]}")
 }
 
 # A well-known private key just for the TPM2_MakeCredential()-based encryption
 # of secrets to TPMs.  It was generated with:
-#  openssl genpkey -genparam                               \
-#                  -algorithm EC                           \
-#                  -out "${d}/ecp.pem"                     \
-#                  -pkeyopt ec_paramgen_curve:secp384r1    \
+#  openssl genpkey -genparam					\
+#                  -algorithm EC				\
+#                  -out ecp.pem					\
+#                  -pkeyopt ec_paramgen_curve:secp384r1		\
 #                  -pkeyopt ec_param_enc:named_curve
-#  openssl genpkey -paramfile "${d}/ecp.pem"
-function wkpriv {
+#  openssl genpkey -paramfile ecp.pem
+#
+#  This key is NEVER used for signing or key exchange (therefore also not for
+#  encryption).  It is only ever used for constructing activation objects whose
+#  cryptographic names will be bound by TPM2_MakeCredential() into its outputs.
+wkpriv() {
 	cat <<"EOF"
 -----BEGIN PRIVATE KEY-----
 MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDAlMnCWue7CfXjNLibH

--- a/sbin/attest-enroll
+++ b/sbin/attest-enroll
@@ -36,7 +36,7 @@ DBDIR="$BASEDIR/build/attest"
 POLICY=
 ESCROW_POLICY=
 ESCROW_PUBS_DIR=
-TRANSPORT_METHOD=EK
+TRANSPORT_METHOD=WK
 DEFAULT_EK_POLICY=
 declare -a GENPROGS
 GENPROGS=(genhostname genrootfskey)
@@ -223,7 +223,7 @@ $(configs)
 		names of hard-coded policies, or names of executables
 		(default: POLICIES[rootkey]=pcr11).
 
-		TRANSPORT_METHOD should be EK or TK (default: EK).
+		TRANSPORT_METHOD should be WK or TK (default: WK).
 
   NOTE: Until https://github.com/tpm2-software/tpm2-tools/issues/2761 is
 	closed, {$PROG} may require a TPM (simulated will suffice) for
@@ -337,14 +337,14 @@ if [[ -n ${DBDIR:-} && -f ${DBDIR:-}/attest-enroll.conf ]]; then
 		configured=true
 	fi
 fi
-[[ ${TRANSPORT_METHOD:-} = @(TK|EK) ]]	\
+[[ ${TRANSPORT_METHOD:-} = @(TK|WK) ]]	\
 || die "TRANSPORT_METHOD must be either 'TK' or 'EK'"
 [[ -z $ESCROW_PUBS_DIR || -d $ESCROW_PUBS_DIR ]] \
 || die "ESCROW_PUBS_DIR -- must be a directory or not given"
 
-# XXX This policy is for the EK method.
+# XXX This policy is for the WK method.
 #
-# FIXME We could make policies for EK/TK have the same digest by using
+# FIXME We could make policies for WK/TK have the same digest by using
 #       TPM2_PolicyOR:
 #
 #       tpm2 policy... -L ...

--- a/sbin/attest-enroll
+++ b/sbin/attest-enroll
@@ -41,6 +41,7 @@ DEFAULT_EK_POLICY=
 declare -a GENPROGS
 GENPROGS=(genhostname genrootfskey)
 declare -A POLICIES
+POLICIES=()
 
 # For the configure function (see below)
 declare -A vars

--- a/sbin/tpm2-policy
+++ b/sbin/tpm2-policy
@@ -24,8 +24,13 @@ Usage: $PROG [options] POLICY
   The second form executes the policyDigest in a policy session saved in
   {SESSION} (a file).
 
-  A {POLICY} starts with an optional TPM 2.0 command-code (e.g., TPM2_CC_Sign),
-  and the rest is a sequence of {tpm2 policy*} command-lines separated by ';':
+  A {POLICY} is either a single argument naming a non-empty file that
+  contains the actual {POLICY}, or it is multiple arguments defining a
+  policy as follows.
+
+  A {POLICY} starts with an optional TPM 2.0 command-code (e.g.,
+  TPM2_CC_Sign), and the rest is a sequence of {tpm2 policy*} command-lines
+  separated by ';':
 
        $PROG ... tpm2 policy... args... \\; tpm2 policy args...
 
@@ -107,6 +112,29 @@ trap 'rm -rf "$d"' EXIT
 d=$(mktemp -d)
 
 : "${policy:="${d}/policy"}"
+
+# Pop the alternatives
+declare -a alternatives
+alternatives=()
+while (($#)) && [[ $1 = [0-9] ]]; do
+	alternatives+=("$1")
+	shift
+done
+
+if (($# == 1)) && [[ -f $1 ]]; then
+	# This idiom is to avoid having to disable SC2046: Quote this to
+	# prevent word splitting, which `set -- $(cat "$1")` raises.
+	policy_file=$1
+	shift
+	declare -a line
+	while read -a line -r; do
+		set -- "$@" "${line[@]}"
+	done < "$policy_file"
+fi
+
+# Put the alternatives back in
+set -- "${alternatives[@]}" "$@"
+
 if [[ -n $session ]]; then
 	(($# > 0)) && [[ $1 = [0-9] && -n $command_code ]]		\
 	&& die "-A and -D are not allowed when using alternations"

--- a/sbin/tpm2-policy
+++ b/sbin/tpm2-policy
@@ -16,15 +16,25 @@ shopt -s extglob
 function usage {
 	((${1:-1} > 0)) && exec 1>&2
 	cat <<EOF
-Usage: $PROG [-o FILE] [-A | -D] POLICY-CMD [ARGS [\\; ...]]
+Usage: $PROG [options] POLICY
+       $PROG [options] -e SESSION POLICY
 
-  The first form computes the policyDigest of the given policy.
+  The first form computes the policyDigest of the given {POLICY}.
 
-  Policies arguments should be of the form:
+  The second form executes the policyDigest in a policy session saved in
+  {SESSION} (a file).
+
+  A {POLICY} starts with an optional TPM 2.0 command-code (e.g., TPM2_CC_Sign),
+  and the rest is a sequence of {tpm2 policy*} command-lines separated by ';':
 
        $PROG ... tpm2 policy... args... \\; tpm2 policy args...
 
   but without any {--session}|{-S} nor {--policy}|{-L} options.
+
+  For alternations use {tpm2 policyor} with each alternative given as a sub-
+  {POLICY} surrounded with '(' and ')':
+
+       $PROG ... tpm2 policyor '(' tpm2 policy... ';' ... ')' '(' ... ') ...
 
   If -A is given then {tpm2 policycommandcode} will be added at the end for
   enabling TPM2_ActivateCredential().
@@ -32,29 +42,55 @@ Usage: $PROG [-o FILE] [-A | -D] POLICY-CMD [ARGS [\\; ...]]
   If -D is given then {tpm2 policycommandcode} will be added at the end for
   enabling TPM2_RSA_Decrypt().
 
+  Options:
+
+   -h	    This message.
+   -v	    Verbose.
+   -x	    Trace.
+
+   -e SESS  Create a policy session {SESS} and execute the {POLICY} in that
+	    session.
+   -f	    Force (overwrite FILE).
+   -o FILE  Where to put the SHA-256 policyDigest (hex-encoded).
+   -p FILE  Where to put the SHA-256 policyDigest (binary).
+   -A	    Add {tpm2 policycommandcode TPM2_CC_ActivateCredential}.
+   -D	    Add {tpm2 policycommandcode TPM2_CC_RSA_Decrypt}.
+
   E.g.:
 
       $ # Require that PCR 11 be unextended
       $ $PROG tpm2 policypcr -l "sha256:11"
+
+      $ # Allow signing and credential activation only
+      $ $PROG tpm2 policyor '(' tpm2 policycommandcode TPM2_CC_Sign ')' \\
+				  '(' tpm2 policycommandcode TPM2_CC_ActivateCredential ')'
 EOF
 	exit "${1:-1}"
 }
+
+(($# == 0)) && usage 0
 
 # shellcheck disable=SC1090
 . "$BASEDIR/../functions.sh"
 
 out=
 force=false
+policy=
+session=
+VERBOSE=0
 activate=false
 rsa_decrypt=false
 command_code=
-while getopts +:ADhefo:x opt; do
+while getopts +:ADhe:fo:p:vx opt; do
 case "$opt" in
 A)	activate=true;;
 D)	rsa_decrypt=true;;
+e)	session=$OPTARG;;
 h)	usage 0;;
 f)	force=true;;
 o)	out=$OPTARG;;
+p)	policy=$OPTARG;;
+v)	((++VERBOSE));;
 x)	set -vx;;
 *)	usage;;
 esac
@@ -70,7 +106,18 @@ d=
 trap 'rm -rf "$d"' EXIT
 d=$(mktemp -d)
 
-policyDigest=$(make_policyDigest $command_code "$@")
+: "${policy:="${d}/policy"}"
+if [[ -n $session ]]; then
+	(($# > 0)) && [[ $1 = [0-9] && -n $command_code ]]		\
+	&& die "-A and -D are not allowed when using alternations"
+
+	# exec_policy will create the policy session
+	exec_policy "$session" "$policy" $command_code "$@"
+	exit 0
+fi
+
+session="${d}/session"
+policyDigest=$(make_policyDigest "$session" "$policy" $command_code "$@")
 [[ -z $out ]] || ! $force >| "$out"
 [[ -z $out ]] ||   $force > "$out"
 echo "$policyDigest"

--- a/sbin/tpm2-recv
+++ b/sbin/tpm2-recv
@@ -19,7 +19,7 @@ Usage: $PROG CIPHERTEXT OUT [POLICY-CMD [ARGS] [;] ...]
 
   If {CIPHERTEXT}.tk.pem, {CIPHERTEXT}.tk.dpriv, {CIPHERTEXT}.tk.pub,
   and {CIPHERTEXT}.tk.seed exist, then the "TK" method of encryption is
-  assumed.  Otherwise the "EK" method of encryption is assumed.
+  assumed.  Otherwise the "WK" method of encryption is assumed.
 
   See {tpm2-send} for details of the two encryption-to-TPM methods
   supported.
@@ -93,7 +93,7 @@ tpm2 createek					\
 	--public "${d}/ek.pub"			\
 || die "tpm2: unable to create ek object"
 
-# Make policyDigest (needed for EK method, when loading the WK)
+# Make policyDigest (needed for WK method, when loading the WK)
 (($# > 0)) && ! $use_tk							\
 && make_policyDigest "${d}/session" "${d}/policy" $command_code "$@"
 

--- a/sbin/tpm2-recv
+++ b/sbin/tpm2-recv
@@ -80,6 +80,9 @@ for i in dpriv pub seed; do
 done
 $use_tk || command_code=TPM2_CC_ActivateCredential
 
+# Don't pass a command-code to exec_policy if the policy refers to one
+[[ "$*" = *TPM2_CC_* ]] && command_code=''
+
 # Get the EK handle
 tpm2 flushcontext --transient-object
 tpm2 flushcontext --loaded-session
@@ -90,8 +93,9 @@ tpm2 createek					\
 	--public "${d}/ek.pub"			\
 || die "tpm2: unable to create ek object"
 
-# Make policyDigest
-(($# > 0)) && make_policyDigest "$command_code" "$@"
+# Make policyDigest (needed for EK method, when loading the WK)
+(($# > 0)) && ! $use_tk							\
+&& make_policyDigest "${d}/session" "${d}/policy" $command_code "$@"
 
 # Create empty auth session for EK
 tpm2 flushcontext --transient-object
@@ -103,13 +107,9 @@ tpm2 policysecret --session "${d}/sessionek.ctx" --object-context endorsement
 function auth {
 	tpm2 flushcontext --transient-object
 	tpm2 flushcontext --loaded-session
-	tpm2 startauthsession			\
-		--session "${d}/session.ctx"	\
-		--policy-session
-	# exec_policy will {die} if we fail to satisfy the policy
-	exec_policy "$command_code" "$@"
+	exec_policy "${d}/session.ctx" "${d}/policy.dat" $command_code "$@"
 	tpm2 flushcontext --transient-object
-	tpm2 flushcontext --loaded-session
+	rm -f "${d}/policy.dat"
 }
 
 if $use_tk; then

--- a/sbin/tpm2-send
+++ b/sbin/tpm2-send
@@ -179,7 +179,7 @@ function wkname_tpm {
 		attrs='adminwithpolicy|sign'
 		has_policy=true
 	elif (($# > 0)); then
-		make_policyDigest "$command_code" "$@" 1>&2
+		make_policyDigest "${d}/sesswk" "${d}/policy" "$command_code" "$@" 1>&2
 		attrs='adminwithpolicy|sign'
 		has_policy=true
 
@@ -251,7 +251,7 @@ TK)	info "Generating TK"
 
 	args=()
 	if (($# > 0)); then
-		make_policyDigest "$command_code" "$@" 1>&2
+		make_policyDigest "${d}/sesstk" "${d}/policy" "$command_code" "$@" 1>&2
 		args=("--policy=${d}/policy")
 	fi
 

--- a/sbin/tpm2-send
+++ b/sbin/tpm2-send
@@ -39,7 +39,7 @@ Usage: $PROG EK-PUB SECRET OUT		 # Null policy
   Options:
 
 	-h		This help message.
-	-M EK|TK	Method to use for encryption to TPM (default: EK).
+	-M WK|TK	Method to use for encryption to TPM (default: WK).
 	-P POLICY	Use the named policy or policyDigest.
 	-f		Overwrite {OUT}.
 	-x		Trace this script.
@@ -65,14 +65,14 @@ Usage: $PROG EK-PUB SECRET OUT		 # Null policy
 
   The two methods of encryption to a TPM are:
 
-   - EK		Uses {TPM2_MakeCredential()} to encrypt an AES key to
+   - WK		Uses {TPM2_MakeCredential()} to encrypt an AES key to
 		the target's EKpub.
 
 		The target uses {TPM2_ActivateCredential()} to decrypt
 		the AES key.
 
-		A well-known key is used as the activation object, and
-		the given policy is associated with it.
+		A well-known key ("WK") is used as the activation object,
+		and the given policy is associated with it.
 		This method produces a single file named {OUT}.
 
    - TK		Uses {TPM2_Duplicate()} to encrypt an RSA private key to
@@ -100,7 +100,7 @@ EOF
 . "$BASEDIR/../functions.sh"
 
 force=false
-method=EK
+method=WK
 policy=
 policyDigest=
 while getopts +:hfxM:P: opt; do
@@ -121,9 +121,9 @@ function err {
 }
 
 case "$method" in
-EK)	command_code=TPM2_CC_ActivateCredential;;
+WK)	command_code=TPM2_CC_ActivateCredential;;
 TK)	command_code=TPM2_CC_RSA_Decrypt;;
-*)	err "METHOD must be \"EK\" or \"TK\"";;
+*)	err "METHOD must be \"WK\" or \"TK\"";;
 esac
 if [[ -n $policy ]] && (($# > 3)); then
 	echo "Error: -P and policy commands are mutually exclusive" 1>&2
@@ -229,7 +229,7 @@ function wkname {
 }
 
 case "$method" in
-EK)	info "Computing WKname"
+WK)	info "Computing WKname"
 	wkname=$(wkname "$@")				\
 	|| die "unable to compute the MakeCredential activation object's cryptographic name"
 	info "Encrypting to EKpub using TPM2_MakeCredential"

--- a/tests/test-enroll.sh
+++ b/tests/test-enroll.sh
@@ -49,7 +49,7 @@ cat > "${d}/attest-enroll.conf" <<EOF
 DBDIR=${d}/db
 POLICY=7fdad037a921f7eec4f97c08722692028e96888f0b970dc7b3bb6a9c97e8f988
 ESCROW_POLICY=
-TRANSPORT_METHOD=EK
+TRANSPORT_METHOD=WK
 GENPROGS+=(gentest0)
 ESCROW_PUBS_DIR=${d}/escrowpubs
 POLICIES[rootfskey]=pcr11

--- a/tests/test-enroll.sh
+++ b/tests/test-enroll.sh
@@ -12,7 +12,7 @@ fi
 
 TOP=${TOP%/*}
 
-# shellcheck source=functions.sh
+# shellcheck disable=SC1091
 . "$TOP/functions.sh"
 
 #PATH=$TOP/sbin:$TOP/swtpm/src/swtpm:$PATH


### PR DESCRIPTION
This allows one to express complex policies (ones with alternations)
using a simple language.

The pattern is simply that conjunctions are `tpm2 policy*` command-lines
joined with a `';'` argument, and alternations are `tpm2 policyor`
commands with arguments that are themselves policies surrounded by `'('`
and `')'` arguments.

For example:

```
    $ sbin/tpm2-policy							\
	tpm2 policyor							\
	    '(' tpm2 policycommandcode TPM2_CC_Sign ')'			\
	    '(' tpm2 policycommandcode TPM2_CC_RSA_Decrypt ')' ';'	\
	tpm2 policypcr -l "sha256:11"
```

which allows an entity sporting such a policy to be used for signing or
decryption only, and only when PCR#11 is cleared.

The same, verbosely:

```
    $ sbin/tpm2-policy -v						\
	tpm2 policyor							\
	    '(' tpm2 policycommandcode TPM2_CC_Sign ')'			\
	    '(' tpm2 policycommandcode TPM2_CC_RSA_Decrypt ')' ';'	\
	tpm2 policypcr -l "sha256:11"
        Running: (AND) exec_policyOR_helper ( tpm2 policycommandcode TPM2_CC_Sign ) ( tpm2 policycommandcode TPM2_CC_RSA_Decrypt ) ;
            Running: (AND) tpm2 policycommandcode --session /tmp/tmp.jbXmSKOtzR/session-0-0 --policy /tmp/tmp.jbXmSKOtzR/policy-0-0 TPM2_CC_Sign
    cc6918b226273b08f5bd406d7f10cf160f0a7d13dfd83b7770ccbcd1aa80d811
    cc6918b226273b08f5bd406d7f10cf160f0a7d13dfd83b7770ccbcd1aa80d811
            Running: (AND) tpm2 policycommandcode --session /tmp/tmp.jbXmSKOtzR/session-0-1 --policy /tmp/tmp.jbXmSKOtzR/policy-0-1 TPM2_CC_RSA_Decrypt
    3c29869a1312094782b86df5a430caae587f5dfb16dfa3f7204151054c1340d2
    3c29869a1312094782b86df5a430caae587f5dfb16dfa3f7204151054c1340d2
        ORing: cc6918b226273b08f5bd406d7f10cf160f0a7d13dfd83b7770ccbcd1aa80d811 3c29869a1312094782b86df5a430caae587f5dfb16dfa3f7204151054c1340d2
        Running: tpm2 policyor --session /tmp/tmp.jbXmSKOtzR/session --policy /tmp/tmp.jbXmSKOtzR/policy sha256:/tmp/tmp.jbXmSKOtzR/policy-0-0,/tmp/tmp.jbXmSKOtzR/policy-0-1
    39faada14fb6d5deba4315d8bce0247813262ebf15e1aee35477d26759f1b29e
        Running: (AND) tpm2 policypcr --session /tmp/tmp.jbXmSKOtzR/session --policy /tmp/tmp.jbXmSKOtzR/policy -l sha256:11
    3b9ea8dca851fac5d077d7b6925b8cc38847619e4b9a0f026ca5cc6262ff8a1c
    3b9ea8dca851fac5d077d7b6925b8cc38847619e4b9a0f026ca5cc6262ff8a1c
    $
```

One can also execute a policy in a policy session using `sbin/tpm2-policy`:

```bash
: ; /safeboot/sbin/tpm2-policy -e sessdup                                       \
        tpm2 policyor '(' tpm2 policycommandcode TPM2_CC_Duplicate ';'          \
                          tpm2 policysecret --object-context primary.ctx ')'    \
                      '(' tpm2 policycommandcode TPM2_CC_Sign ')'
bef56b8c1cc84e11edd717528d2cd99356bd2bbf8f015209c3f84aeeaba8e8a2
6152da7336d14b50adc37165c3b3a75af43426f7fb285b14e0f3e7145c8abf97
6152da7336d14b50adc37165c3b3a75af43426f7fb285b14e0f3e7145c8abf97
cc6918b226273b08f5bd406d7f10cf160f0a7d13dfd83b7770ccbcd1aa80d811
cc6918b226273b08f5bd406d7f10cf160f0a7d13dfd83b7770ccbcd1aa80d811
30f6e1c393911768102f2a8a1ca5218eb6b837e12527d97cc38aae12027c7c9b
30f6e1c393911768102f2a8a1ca5218eb6b837e12527d97cc38aae12027c7c9b
```

Internally we have `exec_policy` in functions.sh that can execute a
policy in either a trial session or in policy session, and if in a
policy session then the caller must supply the indices of alternatives
to take in the policy, otherwise the caller must not supply those.

I.e.,

```bash
    # Compute policyDigest of the policy above:
    tpm2_flushall
    tpm2 startauthsession --session session
    exec_policy session policy						\
	tpm2 policyor							\
	    '(' tpm2 policycommandcode TPM2_CC_Sign ')'			\
	    '(' tpm2 policycommandcode TPM2_CC_RSA_Decrypt ')' ';'	\
	tpm2 policypcr -l "sha256:11"
```

```bash
    # Execute the policy above with the second alternative:
    tpm2_flushall
    tpm2 startauthsession --session session
    exec_policy 1 session policy					\
	tpm2 policyor							\
	    '(' tpm2 policycommandcode TPM2_CC_Sign ')'			\
	    '(' tpm2 policycommandcode TPM2_CC_RSA_Decrypt ')' ';'	\
	tpm2 policypcr -l "sha256:11"
```

This is recursive, so it generalizes to policies of arbitrary
complexity, limited to nesting alternations up to nine (9) times, or the
shell's recursion limit if it be lower.