### PR TITLE
gencert: Support use of OpenSSL for cert issuance

### DIFF
--- a/sbin/gencert
+++ b/sbin/gencert
@@ -20,19 +20,28 @@ else
 	exit 1
 fi
 
-GENCERT_CRED=PEM-FILE:/etc/safeboot/gencert-ca.pem
+GENCERT_CA_PRIV=
+GENCERT_CA_CERT=PEM-FILE:/etc/safeboot/gencert-ca.pem
 GENCERT_REALM=
 GENCERT_KEY_BITS=2048
 GENCERT_INCLUDE_SAN_PKINIT=true
 GENCERT_INCLUDE_SAN_DNSNAME=false
-GENCERT_EKUS=()
+GENCERT_X509_TOOLING=OpenSSL # Or Heimdal
+declare -a GENCERT_EKUS
 declare -A GENCERT_DOMAIN_REALM
+declare -A POLICIES
+GENCERT_EKUS=()
+GENCERT_DOMAIN_REALM=()
 
-cf=$(safeboot_file etc enroll.conf)
-if [[ -n $cf && -f $cf ]]; then
+if [[ -n ${SAFEBOOT_ENROLL_CONF:-} ]]; then
 	# shellcheck disable=SC1090
-	. "$cf"
-	export SAFEBOOT_ENROLL_CONF="$cf"
+	. "$SAFEBOOT_ENROLL_CONF"
+else
+	cf=$(safeboot_file etc enroll.conf)
+	if [[ -n $cf && -f $cf ]]; then
+		# shellcheck disable=SC1090
+		. "$cf"
+	fi
 fi
 
 die() { echo "skip: $*"; echo >&2 "Error: $PROG" "$@" ; exit 1 ; }
@@ -42,6 +51,23 @@ cd "$1"
 outdir=$2
 hostname=$3
 shift 3
+
+${GENCERT_INCLUDE_SAN_PKINIT}					\
+|| ${GENCERT_INCLUDE_SAN_DNSNAME}				\
+|| die 'One of GENCERT_INCLUDE_SAN_{PKINIT,DNSNAME} must be set to true'
+
+declare -a hxtool_ca_opts
+declare -a openssl_x509_opts
+
+hxtool_ca_opts=("--ca-certificate=$GENCERT_CA_CERT")
+openssl_x509_opts=("-CA" "$GENCERT_CA_CERT")
+
+if [[ -n $GENCERT_CA_PRIV ]]; then
+	[[ -n $GENCERT_CA_CERT ]]				\
+	|| die "GENCERT_CA_CERT is not set"
+	hxtool_ca_opts+=("--ca-private-key=$GENCERT_CA_PRIV")
+	openssl_x509_opts+=("-CAkey" "$GENCERT_CA_PRIV")
+fi
 
 if [[ -z $GENCERT_REALM ]]; then
 	domain=${hostname}
@@ -60,46 +86,112 @@ if [[ -z $GENCERT_REALM ]]; then
 	|| die "Could not determine realm name for $hostname"
 fi
 
-sans=()
-
 ${GENCERT_INCLUDE_SAN_PKINIT}					\
-&& sans+=(--pk-init-principal="host/$hostname@$GENCERT_REALM")
+&& hxtool_ca_opts+=(--pk-init-principal="host/$hostname@$GENCERT_REALM")
 
 ${GENCERT_INCLUDE_SAN_DNSNAME}					\
-&& sans+=(--hostname="$hostname")
+&& hxtool_ca_opts+=(--hostname="$hostname")
 
-ekus=()
 if ((${#GENCERT_EKUS[@]} > 0)); then
 	for eku in "${GENCERT_EKUS[@]}"; do
-		ekus+=(--eku="$eku")
+		hxtool_ca_opts+=(--eku="$eku")
 	done
 fi
 
+cat > cert-extensions <<EOF
+[client_cert]
+basicConstraints=CA:FALSE
+keyUsage=digitalSignature,keyEncipherment,keyAgreement
+extendedKeyUsage=@eku_section
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid,issuer
+issuerAltName=issuer:copy
+subjectAltName=critical,@subject_alt_section
+
+[eku_section]
+extendedKeyUsage.800=1.3.6.1.5.2.3.4
+extendedKeyUsage.801=1.3.6.1.5.5.7.3.2
+$(
+	for i in "${!GENCERT_EKUS[@]}"; do
+		printf 'extendedKeyUsage.%s=%s\n'		\
+			"$i" "${GENCERT_EKUS[1]}"
+	done
+)
+
+[subject_alt_section]
+$(${GENCERT_INCLUDE_SAN_DNSNAME}	\
+	&& printf 'DNS.1=${ENV::HOST_NAME}\n')
+$(${GENCERT_INCLUDE_SAN_PKINIT}		\
+	&& printf 'otherName.2=1.3.6.1.5.2.2;SEQUENCE:princ_name\n')
+
+[princ_name]
+realm=EXP:0,GeneralString:\${ENV::GENCERT_REALM}
+principal_name=EXP:1,SEQUENCE:principal_seq
+
+[principal_seq]
+name_type=EXP:0,INTEGER:1
+name_string=EXP:1,SEQUENCE:principals
+
+[principals]
+princ0=GeneralString:\${ENV::SERVICE}
+princ1=GeneralString:\${ENV::HOST_NAME}
+EOF
+
 # Generate the private key (and a CSR, which is kind of unnecessary, but...)
-trap 'rm -f cert-req.der cert-key.pem' EXIT
-hxtool request-create						\
-	--subject=''						\
-	--generate-key=rsa					\
-	--key-bits="$GENCERT_KEY_BITS"				\
-	--key="PEM-FILE:$PWD/cert-key.pem"			\
-	cert-req.der						\
-|| die "Could not generate RSA key!"
-# Format and sign the end-entity certificate
-hxtool issue-certificate					\
-	--type=pkinit-client					\
-	--ca-certificate="$GENCERT_CRED"			\
-	--subject=						\
-	"${sans[@]}"						\
-	"${ekus[@]}"						\
-	--ku=digitalSignature					\
-	--lifetime=10y						\
-	--req="PKCS10:cert-req.der"				\
-	--certificate=PEM-FILE:cert.pem				\
-|| die "skip: Could not issue PKINIT certificate for impersonation!"
+trap 'rm -f cert-extensions cert-req cert-key.pem' EXIT
+
+# Try Heimdal's hxtool
+case "$GENCERT_X509_TOOLING" in
+Heimdal)
+	hxtool request-create						\
+		--subject=''						\
+		--generate-key=rsa					\
+		--key-bits="$GENCERT_KEY_BITS"				\
+		--key="PEM-FILE:cert-key.pem"				\
+		cert-req 2>/dev/null					\
+	|| die "Could not generate a key and make a CSR"
+	! hxtool issue-certificate					\
+		"${hxtool_ca_opts[@]}"					\
+		--type=pkinit-client					\
+		--subject=						\
+		--ku=digitalSignature					\
+		--lifetime=10y						\
+		--req="PKCS10:cert-req"					\
+		--certificate=PEM-FILE:cert.pem 2>/dev/null		\
+	|| die "Could not issue certificate"
+	;;
+OpenSSL)
+	openssl genrsa							\
+		-out cert-key.pem 2048					\
+	|| die "Could not make an RSA key"
+	openssl req							\
+		-new							\
+		-batch							\
+		-subj '/'						\
+		-key cert-key.pem					\
+		-out cert-req						\
+	|| die "Could not make a CSR"
+
+	export GENCERT_REALM
+	export HOST_NAME="$hostname"
+	export SERVICE="host"
+
+	openssl x509							\
+		-set_serial "0x$(_rand 16 | bin2hex)"			\
+		"${openssl_x509_opts[@]}"				\
+		-req							\
+		-in cert-req						\
+		-extensions client_cert					\
+		-extfile cert-extensions				\
+		-days 365						\
+		-out cert.pem						\
+	|| die "Could not make a certificate"
+esac
+
 
 # Append the issuer certificate and any other certs in that file to the output
 # so that the full chain is included.
-openssl crl2pkcs7 -nocrl -certfile "${GENCERT_CRED#*:}"		\
+openssl crl2pkcs7 -nocrl -certfile "${GENCERT_CA_CERT#*:}"		\
 | openssl pkcs7 -print_certs >> cert.pem
 
 grep -q PRIVATE cert.pem && die "Private key in cert file?!"


### PR DESCRIPTION
This commit allows the use of either OpenSSL or Heimdal for certificate issuance.  It also splits up the `GENCERT_CRED` into two pieces so that the private key and the CA certificate can be stored separately, and it fixes config file confusion.