### PR TITLE
Fix for TPM memory error (#159)

### DIFF
--- a/sbin/safeboot
+++ b/sbin/safeboot
@@ -738,6 +738,8 @@ luks-seal() {
 		>> /tmp/tpm.log \
 	|| die "Unable to create TPM key context"
 
+	tpm2_flushall
+	
 	tpm2 load \
 		--parent-context "$TMP/primary.ctx" \
 		--public "$TMP/sealed.pub" \


### PR DESCRIPTION
Fix for the TPM memory error "out of memory for object contexts" at luks-seal (#159 https://github.com/osresearch/safeboot/issues/159)
@osresearch suggestion worked on 11/8/21 to add an additional `tpm2_flushall` "maybe we need an additional one between the tpm2 create and tpm2 load at https://github.com/osresearch/safeboot/blob/master/sbin/safeboot#L741"